### PR TITLE
String glob matching

### DIFF
--- a/src/matchspec.rs
+++ b/src/matchspec.rs
@@ -15,7 +15,7 @@ fn is_match_glob_str(glob_str: &str, package: &str) -> bool {
             return false;
         }
     }
-    return true;
+    true
 }
 
 

--- a/src/matchspec.rs
+++ b/src/matchspec.rs
@@ -18,22 +18,6 @@ fn is_match_glob_str(glob_str: &str, match_str: &str) -> bool {
     true
 }
 
-fn is_match_glob_str_cond(glob_str: &str, match_str: &str) -> bool {
-    if glob_str.contains("*") {
-        let mut index: Option<usize> = Some(0);
-        let mut it = glob_str.split("*").peekable();
-        while let Some(part) = it.next() {
-            index = match_str.get(index.unwrap()..).and_then(|s| s.find(part));
-            if index == None || (it.peek().is_none() && !match_str.ends_with(part)) {
-                return false;
-            }
-        }
-        return true;
-    } else {
-        return glob_str == match_str;
-    }
-}
-
 /// Enum that is used for representating the selector types.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Selector {
@@ -529,14 +513,6 @@ mod test {
             assert!(!or.is_match(&"1.2.1"));
             assert!(!or.is_match(&"1.1.1"));
             assert!(!or.is_match(&"1.1.7"));
-        }
-
-        #[test]
-        fn glob_benchmark() {
-            assert!(is_match_glob_str(&"tensorflow", "tensorflow"));
-            assert!(is_match_glob_str(&"tensorflow-*", "tensorflow-gpu"));
-            assert!(is_match_glob_str_cond(&"tensorflow", "tensorflow"));
-            assert!(is_match_glob_str_cond(&"tensorflow-*", "tensorflow-gpu"));
         }
     }
 }

--- a/src/matchspec.rs
+++ b/src/matchspec.rs
@@ -18,11 +18,6 @@ fn is_match_glob_str(glob_str: &str, match_str: &str) -> bool {
     true
 }
 
-/// Tests a string for forbidden characters
-fn all_chars_legal(input: &str, char_valid: &dyn Fn(char) -> bool) -> bool {
-  input.chars().all(char_valid)
-}
-
 /// Enum that is used for representating the selector types.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Selector {
@@ -425,7 +420,7 @@ impl<S: AsRef<str> + PartialOrd + PartialEq<str> + Into<String>> MatchSpec<S> {
     /// assert!(ms.is_package_match("openssl".to_string()));
     /// ```
     pub fn is_package_match(&self, package: S) -> bool {
-        all_chars_legal(package.as_ref(), &is_alphanumeric_with_dashes)
+        package.as_ref().chars().all(is_alphanumeric_with_dashes)
             && is_match_glob_str(self.package.as_ref(), package.as_ref())
     }
 
@@ -445,7 +440,7 @@ impl<S: AsRef<str> + PartialOrd + PartialEq<str> + Into<String>> MatchSpec<S> {
         package: &V,
         version: &V,
     ) -> bool {
-        all_chars_legal(package.as_ref(), &is_alphanumeric_with_dashes)
+        package.as_ref().chars().all(is_alphanumeric_with_dashes)
             && is_match_glob_str(self.package.as_ref(), package.as_ref())
             && self.is_version_match(version)
     }

--- a/src/matchspec.rs
+++ b/src/matchspec.rs
@@ -5,6 +5,20 @@ use nom::Finish;
 use std::fmt::Debug;
 use std::str::FromStr;
 
+/// Matches a string with a string (possibly) containing globs
+fn is_match_glob_str(glob_str: &str, package: &str) -> bool {
+    let mut index: Option<usize> = Some(0);
+    let mut it = glob_str.split("*").peekable();
+    while let Some(part) = it.next() {
+        index = package.get(index.unwrap()..).and_then(|s| s.find(part));
+        if index == None || (it.peek().is_none() && !package.ends_with(part)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+
 /// Enum that is used for representating the selector types.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Selector {

--- a/src/matchspec.rs
+++ b/src/matchspec.rs
@@ -452,10 +452,22 @@ mod test {
 
         #[test]
         fn package_only() {
-            let ms: MatchSpec<String> = "tensorflow".parse().unwrap();
+            let mut ms: MatchSpec<String> = "tensorflow".parse().unwrap();
 
             assert!(ms.is_package_match("tensorflow".to_string()));
             assert!(!ms.is_package_match("pytorch".to_string()));
+
+            ms = "tensor*-gpu".parse().unwrap();
+            assert!(ms.is_package_match("tensorflow-gpu".to_string()));
+            assert!(!ms.is_package_match("tennnnsorflow-gpu".to_string()));
+
+            ms = "tensorflow*".parse().unwrap();
+            assert!(ms.is_package_match("tensorflow".to_string()));
+            assert!(ms.is_package_match("tensorflow-gpu".to_string()));
+
+            ms = "*-gpu".parse().unwrap();
+            assert!(ms.is_package_match("tensorflow-gpu".to_string()));
+            assert!(!ms.is_package_match("tensorflow".to_string()));
         }
 
         #[test]

--- a/src/matchspec.rs
+++ b/src/matchspec.rs
@@ -430,7 +430,7 @@ impl<S: AsRef<str> + PartialOrd + PartialEq<str> + Into<String>> MatchSpec<S> {
     /// assert!(ms.is_package_match("openssl".to_string()));
     /// ```
     pub fn is_package_match(&self, package: S) -> bool {
-        all_chars_legal(package.as_ref())
+        all_chars_legal(package.as_ref(), &is_alphanumeric_with_dashes)
             && is_match_glob_str(self.package.as_ref(), package.as_ref())
     }
 

--- a/src/matchspec.rs
+++ b/src/matchspec.rs
@@ -20,12 +20,7 @@ fn is_match_glob_str(glob_str: &str, match_str: &str) -> bool {
 
 /// Tests a string for forbidden characters
 fn all_chars_legal(input: &str, char_valid: &dyn Fn(char) -> bool) -> bool {
-    for c in input.chars() {
-        if !char_valid(c) {
-            return false;
-        }
-    }
-    true
+  input.chars().all(char_valid)
 }
 
 /// Enum that is used for representating the selector types.

--- a/src/matchspec.rs
+++ b/src/matchspec.rs
@@ -413,7 +413,7 @@ where
 }
 
 impl<S: AsRef<str> + PartialOrd + PartialEq<str> + Into<String>> MatchSpec<S> {
-    /// Does simple &str equality matching against the package name
+    /// Matches package names. The matchspec package may contain globs
     /// ```
     /// use ::matchspec::*;
     ///
@@ -421,7 +421,7 @@ impl<S: AsRef<str> + PartialOrd + PartialEq<str> + Into<String>> MatchSpec<S> {
     /// assert!(ms.is_package_match("openssl".to_string()));
     /// ```
     pub fn is_package_match(&self, package: S) -> bool {
-        self.package == package
+        is_match_glob_str(self.package.as_ref(), package.as_ref())
     }
 
     /// Uses the Selector embedded in the matchspec to do a match on only a version
@@ -440,7 +440,7 @@ impl<S: AsRef<str> + PartialOrd + PartialEq<str> + Into<String>> MatchSpec<S> {
         package: &V,
         version: &V,
     ) -> bool {
-        self.package.as_ref() == package.as_ref() && self.is_version_match(version)
+        is_match_glob_str(self.package.as_ref(), package.as_ref()) && self.is_version_match(version)
     }
 }
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -12,12 +12,12 @@ use nom::{
 };
 
 /// Tests for alphanumeric with dashes, underscores, or periods
-fn is_alphanumeric_with_dashes(c: char) -> bool {
+pub(crate) fn is_alphanumeric_with_dashes(c: char) -> bool {
     is_alphabetic(c as u8) || is_digit(c as u8) || c == '-' || c == '_'
 }
 
 /// Tests for alphanumeric with dashes, underscores, or periods
-fn is_alphanumeric_with_dashes_or_period(c: char) -> bool {
+pub(crate) fn is_alphanumeric_with_dashes_or_period(c: char) -> bool {
     is_alphanumeric_with_dashes(c) || c == '.'
 }
 
@@ -26,7 +26,7 @@ fn is_alphanumeric_with_dashes_or_period(c: char) -> bool {
 // * Periods: `.`
 // * dashes or underscores: `-`, `_`
 // * glob character (asterisk): `*`
-fn is_any_valid_str_with_glob(c: char) -> bool {
+pub(crate) fn is_any_valid_str_with_glob(c: char) -> bool {
     is_alphanumeric_with_dashes_or_period(c) || c == '*'
 }
 


### PR DESCRIPTION
This implements a fairly primitive glob matcher for strings. Sanitizing is done separately, but could potentially be done in the same function.

Partially addresses issue #14 