### PR TITLE
Fixing benches with feature=python

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 python-source = "python"
 
 [lib]
+# This is the python target
 name = "rust_matchspec"
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
@@ -19,6 +20,11 @@ serde_json = "1.0"
 
 [dev-dependencies]
 criterion = "0.3"
+
+[features]
+default = ["python"]
+json = []
+python = []
 
 [[bench]]
 name = "parsing"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Conda MatchSpec implementation in pure Rust. This allows you to parse a matchs
 The way you instantiate a MatchSpec is by parsing a string into the type:
 
 ```rust
-use matchspec::MatchSpec;
+use rust_matchspec::{CompoundSelector, MatchSpec, Selector};
 
 // Create the MatchSpec by parsing a String or &str
 let matchspec: MatchSpec<String> = "main/linux-64::pytorch>1.10.2".parse().unwrap();
@@ -20,8 +20,8 @@ assert_eq!(&matchspec.package, "pytorch");
 assert_eq!(matchspec.channel, Some("main".to_string()));
 assert_eq!(
 	matchspec.version,
-	Some(matchspec::CompoundSelector::Single {
-		selector: matchspec::Selector::GreaterThan,
+	Some(CompoundSelector::Single {
+		selector: Selector::GreaterThan,
 		version: "1.10.2".to_string(),
 	})
 );
@@ -40,8 +40,9 @@ This library contains benchmarks aimed at checking the speed of our implementati
 These benchmarks use [Criterion.rs](https://bheisler.github.io/criterion.rs/book/criterion_rs.html) to provide the benchmarking framework. Its pretty easy to run the benchmarks on stable rust:
 
 ```bash
+cargo bench 
+
+# Or if you're on mac and get errors with Invalid Symbols:
 cargo bench --no-default-features
 ```
-**Note:** You must use `--no-default-features` because including the `pyo3` depedencies will cause the build to fail with a benchmark target.
-
 This will automatically track benchmark timings across runs. If you do this on a laptop or workstation be aware that you may have regressions show up if you have background processes or other things happening. I would recommend always running the benchmarks at a similar level of CPU load. If you want consistent testing its probably best to quit your browser or anything in the background that might be eating CPU or doing IO.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ This library contains benchmarks aimed at checking the speed of our implementati
 These benchmarks use [Criterion.rs](https://bheisler.github.io/criterion.rs/book/criterion_rs.html) to provide the benchmarking framework. Its pretty easy to run the benchmarks on stable rust:
 
 ```bash
-cargo bench
+cargo bench --no-default-features
 ```
+**Note:** You must use `--no-default-features` because including the `pyo3` depedencies will cause the build to fail with a benchmark target.
 
 This will automatically track benchmark timings across runs. If you do this on a laptop or workstation be aware that you may have regressions show up if you have background processes or other things happening. I would recommend always running the benchmarks at a similar level of CPU load. If you want consistent testing its probably best to quit your browser or anything in the background that might be eating CPU or doing IO.

--- a/benches/parsing.rs
+++ b/benches/parsing.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use matchspec::matchspec::MatchSpec;
+use rust_matchspec::matchspec::MatchSpec;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,16 +6,20 @@ pub mod package_candidate;
 
 pub use crate::matchspec::*;
 
+#[cfg(feature="python")]
 use pyo3::prelude::*;
+#[cfg(feature="python")]
 use pyo3::wrap_pyfunction;
 
 
+#[cfg(feature="python")]
 #[pyfunction]
 fn match_against_matchspec(matchspec: String, package: String, version: String) -> bool {
   let ms: matchspec::MatchSpec<String> = matchspec.parse().unwrap();
   ms.is_package_version_match(&package, &version)
 }
 
+#[cfg(feature="python")]
 #[pymodule]
 fn rust_matchspec(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(match_against_matchspec, m)?)?;

--- a/src/matchspec.rs
+++ b/src/matchspec.rs
@@ -99,7 +99,7 @@ impl Default for CompoundSelector<String> {
 
 /// Create a selector from a parser tuple:
 /// ```
-/// use matchspec::{Selector, CompoundSelector};
+/// use rust_matchspec::{Selector, CompoundSelector};
 ///
 /// let cs = CompoundSelector::from((">", "1.1.1"));
 /// assert_eq!(cs, CompoundSelector::Single{
@@ -140,7 +140,7 @@ where
 {
     /// This takes a versions and tests that it falls within the constraints of this CompoundSelector
     /// ```
-    ///  use matchspec::{Selector, CompoundSelector};
+    ///  use rust_matchspec::{Selector, CompoundSelector};
     ///
     ///  let single = CompoundSelector::Single {
     ///     selector: Selector::GreaterThan,
@@ -206,7 +206,7 @@ where
 
 /// Create a selector from a parser tuple:
 /// ```
-/// use matchspec::{Selector, CompoundSelector};
+/// use rust_matchspec::{Selector, CompoundSelector};
 ///
 /// let cs = CompoundSelector::from((">", "1.1.1", ",", "<", "3.0.0"));
 /// assert_eq!(cs, CompoundSelector::And{
@@ -418,7 +418,7 @@ where
 impl<S: AsRef<str> + PartialOrd + PartialEq<str> + Into<String>> MatchSpec<S> {
     /// Matches package names. The matchspec package may contain globs
     /// ```
-    /// use ::matchspec::*;
+    /// use rust_matchspec::matchspec::*;
     ///
     /// let ms: MatchSpec<String> = "openssl>1.1.1a".parse().unwrap();
     /// assert!(ms.is_package_match("openssl".to_string()));
@@ -430,7 +430,7 @@ impl<S: AsRef<str> + PartialOrd + PartialEq<str> + Into<String>> MatchSpec<S> {
 
     /// Uses the Selector embedded in the matchspec to do a match on only a version
     /// ```
-    /// use ::matchspec::*;
+    /// use rust_matchspec::matchspec::*;
     ///
     /// let ms: MatchSpec<String> = "openssl>1.1.1a".parse().unwrap();
     /// assert!(ms.is_version_match(&"1.1.1r"));

--- a/src/package_candidate.rs
+++ b/src/package_candidate.rs
@@ -30,7 +30,7 @@ impl<S> From<S> for PackageCandidate
 
 impl PackageCandidate {
     pub fn is_match(&self, ms: &MatchSpec<String>) -> bool {
-        ms.is_match(&self)
+        ms.is_match(self)
     }
 }
 


### PR DESCRIPTION
Moved the `pyo3` stuff behind a feature flag that is enabled by default. In order to run the benches you do this now:
```
cargo bench --no-default-features
```
And everything should work.

Stubbed out the json support feature as well, but it doesn't do anything yet.