### PR TITLE
Parallel matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matchspec"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]
@@ -15,6 +15,7 @@ pyo3 = { version = "0.18", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 version-compare = "0.1"
+rayon = "1.7"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,38 @@ Possible keys:
 | subdir       | str           |           |
 | timestamp    | u64           |           |
 
+## `parallel_filter_package_list()`
+
+Using all available cores will take a `list` of `dicts` and returns all the dicts inside that match a given matchspec. The `dicts` must have a `name` key with a `str` value, but all other fields are optional.
+
+**Note** Probably won't show any noticable speed improvements until your list of packages is in the millions.
+
+```python
+import rust_matchspec
+list = [{'name': 'tensorflow', 'version': '2.10.0'},
+	{'name': 'pytorch', 'version': '2.0.0'},
+	{'name': 'pytorch', 'version': '1.11.1'}]
+
+rust_matchspec.parallel_filter_package_list('pytorch>1.12', list) # returns [PackageCandidate(name=pytorch)]
+```
+
+## `parallel_filter_package_list_with_matchspec_list()`
+
+Using all available cores will take a `list` of `dicts` and a `list` of Matchspecs (as `str`) and returns all the dicts inside that match any given matchspec. The `dicts` must have a `name` key with a `str` value, but all other fields are optional. **May contain duplicates** since it runs all of the matchspecs against the package list in parallel and does not dedup the resulting matches.
+
+In my testing this has a very small overhead, but matching 4 matchspecs is approximately the same speed as matching a single matchspec with the other functions.
+
+```python
+import rust_matchspec
+package_list = [{'name': 'tensorflow', 'version': '2.10.0'},
+	{'name': 'pytorch', 'version': '2.0.0'},
+	{'name': 'pytorch', 'version': '1.11.1'}]
+
+matchspec_list = ['python>=3.9.1', 'pytorch>1.12']
+
+rust_matchspec.parallel_filter_package_list_with_matchspec_list(matchspec_list, package_list) # returns [PackageCandidate(name=pytorch)]
+```
+
 # Rust Library
 
 ## Example

--- a/benches/test_python.py
+++ b/benches/test_python.py
@@ -8,50 +8,35 @@ depends_file = test_data / 'linux_64-depends.txt'
 repodata_file = test_data / 'repodata-linux-64.json'
 
 
-def bench_match_against_matchspec(list: [str]):
-    """ Takes the list of matchspecs and matches against python 3.9.1 """
-    for item in list:
-        rust_matchspec.match_against_matchspec(item, 'python', '3.9.1')
-
-
 def test_rust_matchspec_on_repodata_depends(benchmark):
     """
     Test the rust_matchspec.match_against_matchspec using the
     linux_64-depends.txt file.
     """
+    def bench_match_against_matchspec(list: [str]):
+        for item in list:
+            rust_matchspec.match_against_matchspec(item, 'python', '3.9.1')
+
     with open(depends_file) as f:
         depends = f.readlines()
 
     benchmark(bench_match_against_matchspec, list=depends)
 
 
-def bench_conda_against_repodata_depends(list: [str]):
-    """
-    Runs a list of matchspecs against a static package, this is a little
-    contrived, but it is meant to compare the instantiation and filtering speed
-    of MatchSpec
-    """
-    for item in list:
-        ms = MatchSpec(item)
-        ms.match({'name': 'python', 'version': '3.9.1',
-                 'build': 'hbdb9e5c_0', 'build_number': 0})
-
-
 def test_conda_matchspec_on_repodata_depends(benchmark):
     """
     Test Conda's MatchSpec against the linux_64-depends.txt file
     """
+    def bench_conda_against_repodata_depends(list: [str]):
+        for item in list:
+            ms = MatchSpec(item)
+            ms.match({'name': 'python', 'version': '3.9.1',
+                     'build': 'hbdb9e5c_0', 'build_number': 0})
+
     with open(depends_file) as f:
         depends = f.readlines()
 
     benchmark(bench_conda_against_repodata_depends, list=depends)
-
-
-def bench_rust_matchspec_filter_package_list(list: [dict[str, str]]):
-    """
-    Runs rust_matchspec.filter_package_list() against a list of packages
-    """
-    _matches = rust_matchspec.filter_package_list('python>=3.9.1', list)
 
 
 def test_rust_matchspec_filter_package_list(benchmark):
@@ -59,18 +44,44 @@ def test_rust_matchspec_filter_package_list(benchmark):
     Test rust_matchspec's filter_package_list() against the full linux-64
     repodata.json from Anaconda's defaults.
     """
+    def bench_rust_matchspec_filter_package_list(list: [dict[str, str]]):
+        _matches = rust_matchspec.filter_package_list('python>=3.9.1', list)
+
     with open(repodata_file) as f:
         repodata = list(json.load(f)['packages'].values())
 
     benchmark(bench_rust_matchspec_filter_package_list, list=repodata)
 
 
-def bench_conda_filter_package_list(list: [dict[str, str]]):
+def test_rust_matchspec_parallel_filter_package_list(benchmark):
     """
-    Runs uses MatchSpec against a list of packages to filter out non-matches
+    Test rust_matchspec's filter_package_list() against the full linux-64
+    repodata.json from Anaconda's defaults.
     """
-    ms = MatchSpec('python>=3.9.1')
-    _matches = [p for p in list if ms.match(p)]
+    def bench(list: [dict[str, str]]):
+        _matches = rust_matchspec.parallel_filter_package_list(
+            'python>=3.9.1', list)
+
+    with open(repodata_file) as f:
+        repodata = list(json.load(f)['packages'].values())
+
+    benchmark(bench, list=repodata)
+
+
+def test_rust_matchspec_parallel_filter_package_list_with_matchspec_list(benchmark):
+    """
+    Test rust_matchspec's filter_package_list() against the full linux-64
+    repodata.json from Anaconda's defaults.
+    """
+    def bench(list: [dict[str, str]]):
+        ms = ['python>=3.9.1', 'openssl>1', 'tensorflow<2.0', 'pip']
+        _m = rust_matchspec.parallel_filter_package_list_with_matchspec_list(
+            ms, list)
+
+    with open(repodata_file) as f:
+        repodata = list(json.load(f)['packages'].values())
+
+    benchmark(bench, list=repodata)
 
 
 def test_conda_filter_package_list(benchmark):
@@ -78,6 +89,11 @@ def test_conda_filter_package_list(benchmark):
     Benchmark conda MatchSpec filtering all of the linux-64 repodata from
     Anaconda's defaults
     """
+
+    def bench_conda_filter_package_list(list: [dict[str, str]]):
+        ms = MatchSpec('python>=3.9.1')
+        _matches = [p for p in list if ms.match(p)]
+
     with open(repodata_file) as f:
         repodata = list(json.load(f)['packages'].values())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["maturin>=0.14,<0.15"]
 
 [project]
 name = "rust_matchspec"
-version = "0.2.0"
+version = "0.2.1"
 description = "A conda matchspec written in Rust"
 requires-python = ">=3.7"
 classifiers = [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - rust_win-64  # [win]
   host:
     - python
-    - maturin <=13.0,<14.0
+    - maturin <=14.0,<15.0
   run:
     - python
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use pyo3::PyErr;
 use std::{error::Error, fmt::Display, fmt::Formatter};
 
 #[derive(Debug, PartialEq)]
@@ -10,5 +11,11 @@ impl Error for MatchSpecError {}
 impl Display for MatchSpecError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.message)
+    }
+}
+
+impl From<MatchSpecError> for PyErr {
+    fn from(value: MatchSpecError) -> Self {
+        pyo3::exceptions::PyValueError::new_err(value.message)
     }
 }

--- a/src/package_candidate.rs
+++ b/src/package_candidate.rs
@@ -21,6 +21,10 @@ pub struct PackageCandidate {
     pub timestamp: Option<u64>,
 }
 
+// These are safe to assume because Option, String, and u64 are all Send/Sync
+unsafe impl Send for PackageCandidate {}
+unsafe impl Sync for PackageCandidate {}
+
 impl From<&str> for PackageCandidate {
     fn from(s: &str) -> Self {
         let package_candidate: PackageCandidate = serde_json::from_str(s).unwrap();
@@ -109,6 +113,13 @@ impl PackageCandidate {
                 .get_item("build_number")
                 .and_then(|i| PyAny::extract(i).ok()),
         })
+    }
+}
+
+impl TryFrom<&PyDict> for PackageCandidate {
+    type Error = PyErr;
+    fn try_from(value: &PyDict) -> Result<Self, Self::Error> {
+        PackageCandidate::from_dict(value)
     }
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -2,17 +2,31 @@ use crate::matchspec::MatchSpec;
 use crate::package_candidate::PackageCandidate;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
-use pyo3::{create_exception, exceptions::PyException, wrap_pyfunction};
-
-create_exception!(rust_matchspec, MatchSpecParsingError, PyException);
+use pyo3::wrap_pyfunction;
+use rayon::prelude::*;
 
 #[pymodule]
 fn rust_matchspec(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(match_against_matchspec, m)?)?;
     m.add_function(wrap_pyfunction!(filter_package_list, m)?)?;
+    m.add_function(wrap_pyfunction!(parallel_filter_package_list, m)?)?;
+    m.add_function(wrap_pyfunction!(parallel_filter_package_list_with_matchspec_list, m)?)?;
     m.add_class::<MatchSpec>()?;
     m.add_class::<PackageCandidate>()?;
     Ok(())
+}
+
+/// Conversion function to take a PyList and get a native Vec<PackageCandidate>
+fn try_pylist_into_vec_of_package_candidates(
+    list: &PyList,
+) -> Result<Vec<PackageCandidate>, PyErr> {
+    let mut accumulator: Vec<PackageCandidate> = vec![];
+    for d in list.into_iter() {
+        let dict: &PyDict = d.downcast::<PyDict>()?;
+        let pc = PackageCandidate::try_from(dict)?;
+        accumulator.push(pc)
+    }
+    Ok(accumulator)
 }
 
 /// This function matches matchspec string against package name and version
@@ -57,4 +71,59 @@ fn filter_package_list(
     err?;
 
     Ok(pylist.into())
+}
+
+/// Filters a list of package dictionaries against a matchspec in parallel. This doesn't give a
+/// noticable speed increase until the list of packages is in the millions
+#[pyfunction]
+#[pyo3(signature = (matchspec, package_list))]
+fn parallel_filter_package_list(
+    matchspec: String,
+    package_list: &PyList,
+) -> Result<Vec<PackageCandidate>, PyErr> {
+    let ms = matchspec.parse()?;
+    let list = try_pylist_into_vec_of_package_candidates(package_list)?;
+
+    Ok(list
+        .par_iter()
+        .with_min_len(1000)
+        .filter(|pc| pc.is_match(&ms))
+        .cloned()
+        .collect())
+}
+
+/// Helper function to filter a list of PackageCandidate against a MatchSpec
+fn filter_package_vec(
+    matchspec: &MatchSpec,
+    package_list: &[PackageCandidate],
+) -> Vec<PackageCandidate> {
+    package_list
+        .iter()
+        .filter(|pc| pc.is_match(matchspec))
+        .cloned()
+        .collect()
+}
+
+/// Takes a list of package dictionaries and filters it based on a list of matchspecs. This runs
+/// each matchspec against the package list in paralell, and returns a flat list of package
+/// candidates that match any of the given matchspecs.
+#[pyfunction]
+#[pyo3(signature = (matchspecs, package_list))]
+fn parallel_filter_package_list_with_matchspec_list(
+    matchspecs: Vec<String>,
+    package_list: &PyList,
+) -> Result<Vec<PackageCandidate>, PyErr> {
+    let mut matchspec_list: Vec<MatchSpec> = Vec::new();
+    for maybe_matchspec in matchspecs {
+        let ms: MatchSpec = maybe_matchspec.parse()?;
+        matchspec_list.push(ms);
+    }
+
+    let package_candidate_list: Vec<PackageCandidate> =
+        try_pylist_into_vec_of_package_candidates(package_list)?;
+
+    Ok(matchspec_list
+        .par_iter()
+        .flat_map(|ms| filter_package_vec(ms, &package_candidate_list))
+        .collect())
 }


### PR DESCRIPTION
* Adds Python Errors for matchspec parsing
* `parallel_filter_package_list` for filtering a huge package list
* `parallel_filter_package_list_with_matchspec_list` for filtering a package list with a matchspec list