### PR TITLE
Support OSX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ rayon = "1.7"
 [dev-dependencies]
 criterion = "0.3"
 
+[build-dependencies]
+pyo3-build-config = "0.21"
+
 [features]
 default = ["python"]
 python = ["pyo3/extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matchspec"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [lib]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "macos") {
+        pyo3_build_config::add_extension_module_link_args();
+    }
+}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: rust_matchspec
-  version: 0.2.1
+  version: 0.2.2
 
 source:
   path: ../


### PR DESCRIPTION
Currently this fails to build on OSX due to PYO3 (https://pyo3.rs/main/building-and-distribution#macos)

This enables the necessary linkage flags on OSX only, to make it easier to compile locally.